### PR TITLE
Simplify logic behind `last_change` generations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ Please make sure to add your changes to the appropriate categories:
 - Moved `get()` method from `Progress` into `Controller`.
 - Relaxed memory ordering from `Ordering::SeqCst` to `Ordering::Relaxed`.
 - Moved `last_change` from `Task` into `atomic_state` field of `Progress`.
+- Simplified logic behind `last_change` generations, removing need for shared `last_tree_change`.
 
 ### Deprecated
 
@@ -52,7 +53,7 @@ Please make sure to add your changes to the appropriate categories:
 
 ### Fixed
 
-- n/a
+- Fixed bug in `last_change` bumping logic.
 
 ### Performance
 

--- a/src/generation.rs
+++ b/src/generation.rs
@@ -17,6 +17,15 @@ impl Generation {
     pub fn as_raw(&self) -> usize {
         self.0
     }
+
+    pub(crate) fn add(self, increment: usize) -> (Self, bool) {
+        let (value, overflow) = self.0.overflowing_add(increment);
+        (Self(value), overflow)
+    }
+
+    pub(crate) fn max(self, other: Generation) -> Self {
+        Self(self.0.max(other.0))
+    }
 }
 
 pub(crate) struct AtomicGeneration(pub(crate) AtomicUsize);
@@ -32,8 +41,12 @@ impl AtomicGeneration {
         Generation(self.0.load(order))
     }
 
-    pub(crate) fn store(&self, generation: Generation, order: Ordering) {
-        self.0.store(generation.0, order)
+    pub(crate) fn swap(&self, generation: Generation, order: Ordering) -> Generation {
+        Generation(self.0.swap(generation.0, order))
+    }
+
+    pub(crate) fn fetch_max(&self, generation: Generation, order: Ordering) -> Generation {
+        Generation(self.0.fetch_max(generation.0, order))
     }
 
     pub(crate) fn fetch_add(&self, increment: usize, order: Ordering) -> Generation {


### PR DESCRIPTION
… removing need for shared `last_tree_change` by having the `last_change` be "bubbled up".

This also fixes a small bug in the previous bumping logic that could result in the parent's `last_change` not being updated appropriately.